### PR TITLE
Clarify predownload SnpEff dbs, use uncomp. files

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ CovGen -o Agilent_SureSelect_V5_plusUTR \
   -e ENSG_list_to_filter_out.txt 
 ```
 
+Please make sure to pre-download the SnpEff database using e.g. `java -jar snpEff.jar download GRCh37.74`.
+Also ensure that all input files e.g. FASTA, GTF, and BED are uncompressed.
 
 www.tgen.org
-


### PR DESCRIPTION
Fixes #14 by setting a pre-condition that SnpEff databases are already downloaded.